### PR TITLE
Create preliminary .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 node_modules/
-src/scripts/
-build/
-build-copy/
-logs/
-settings/
+/src/scripts/
+/build/
+/build-copy/
+/logs/
+/settings/
 
-config.json
+/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+src/scripts/
+build/
+build-copy/
+logs/
+settings/
+
+config.json


### PR DESCRIPTION
Ignores build artifcats, but not src/ts/generated. Should at least shut VSCode up about reading over node_modules.

Fixes #33 