### PR TITLE
GitHub Actions: build and lint jobs

### DIFF
--- a/.github/ci-config.json
+++ b/.github/ci-config.json
@@ -1,0 +1,32 @@
+{
+	"title": "Pixel Horse CI",
+	"contactEmail": "noreply@pony.dev",
+	"port": 8090,
+	"adminPort": 8091,
+	"host": "http://localhost:8090/",
+	"local": "localhost:8090",
+	"adminLocal": "localhost:8091",
+	"secret": "pixel",
+	"token": "horse",
+	"db": "mongodb://pixel:horse@mongo:27017/pixelhorse",
+	"oauth": {
+		"google": {
+			"clientID": "snake",
+			"clientSecret": "oil"
+		}
+	},
+	"assetsPath": "assets-source",
+	"servers": [
+		{
+			"id": "ci",
+			"port": 8090,
+			"path": "/s00/ws",
+			"local": "localhost:8090",
+			"name": "CI test server",
+			"desc": "GitHub Actions checking in",
+			"flags": {
+				"test": false
+			}
+		}
+	]
+}

--- a/.github/ci-config.json
+++ b/.github/ci-config.json
@@ -1,5 +1,5 @@
 {
-	"title": "Pixel Horse CI",
+	"title": "pixel.horse CI",
 	"contactEmail": "noreply@pony.dev",
 	"port": 8090,
 	"adminPort": 8091,

--- a/.github/ci-install-gulp.sh
+++ b/.github/ci-install-gulp.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+mkdir "${HOME}/.npm"
+npm config set prefix "${HOME}/.npm"
+npm install -g gulp

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,30 @@
+name: Push Checks
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: install gulp
+        run: bash .github/ci-install-gulp.sh
+      - run: npm ci
+      - name: write config.json
+        run: cp .github/ci-config.json config.json
+      - run: npm run lint
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: install gulp
+        run: bash .github/ci-install-gulp.sh
+      - run: npm ci
+      - name: write config.json
+        run: cp .github/ci-config.json config.json
+      - run: npm run build


### PR DESCRIPTION
🎉 

If we need to introduce new scripts in the future that need mongo to run at the same time, [a job like](https://gist.github.com/judge2020/f8645088d0e75479e63b3e12527fa88c) so would work ([reference](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idservices)).