### PR TITLE
Use season in entity draw options for map renderer tool

### DIFF
--- a/src/ts/components/tools/tools-map/tools-map.ts
+++ b/src/ts/components/tools/tools-map/tools-map.ts
@@ -6,7 +6,7 @@ import { tileHeight, tileWidth, REGION_SIZE } from '../../../common/constants';
 import { faHome } from '../../../client/icons';
 import { updateMap, getTile, createWorldMap, setRegion, setTile } from '../../../common/worldMap';
 import {
-	Season, DrawOptions, defaultDrawOptions, EntityFlags, Entity, WorldMap, defaultWorldState, MapType, MapFlags
+	Season, DrawOptions, defaultDrawOptions, EntityFlags, Entity, WorldMap, MapType, MapFlags
 } from '../../../common/interfaces';
 import { drawCanvas } from '../../../graphics/contextSpriteBatch';
 import { paletteSpriteSheet } from '../../../generated/sprites';
@@ -138,6 +138,7 @@ function drawTheMap(canvas: HTMLCanvasElement, map: WorldMap, info: ToolsMapOthe
 			...defaultDrawOptions,
 			tileGrid: grid,
 			shadowColor: getShadowColor(lightData, HOUR_LENGTH * 12),
+			season: info.season
 		};
 
 		const ignoreTypes = [
@@ -149,7 +150,7 @@ function drawTheMap(canvas: HTMLCanvasElement, map: WorldMap, info: ToolsMapOthe
 		};
 
 		map.entitiesDrawable = info.entities
-			.map(({ type, id, x, y }) => createAnEntity(type, id, x, y, {}, mockPaletteManager, defaultWorldState))
+			.map(({ type, id, x, y }) => createAnEntity(type, id, x, y, {}, mockPaletteManager, { season: info.season }))
 			.filter(shouldDraw);
 
 		updateMap(map, 0);
@@ -183,7 +184,7 @@ function drawMinimap(canvas: HTMLCanvasElement, map: WorldMap, info: ToolsMapOth
 	}
 
 	map.entities = info.entities
-		.map(({ type, id, x, y }) => createAnEntity(type, id, x, y, {}, mockPaletteManager, defaultWorldState));
+		.map(({ type, id, x, y }) => createAnEntity(type, id, x, y, {}, mockPaletteManager, { season: info.season }));
 
 	for (let i = 1; i <= 2; i++) {
 		for (const e of map.entities) {


### PR DESCRIPTION
Fixes #95. Now we can make high resolution renders of any map state!