### PR TITLE
Add manual camera panning

### DIFF
--- a/src/ts/client/game.ts
+++ b/src/ts/client/game.ts
@@ -927,7 +927,7 @@ export class PonyTownGame implements Game {
 			const hover = screenToWorld(camera, cursor);
 
 			this.panning =
-				this.input.isPressed(Key.SHIFT) &&
+				this.input.isPressed(Key.CTRL) &&
 				this.input.isPressed(Key.MOUSE_BUTTON1) ?
 				screenToPanning(camera, cursor) : undefined;
 			updateCamera(camera, player, this.map, this.panning);

--- a/src/ts/common/camera.ts
+++ b/src/ts/common/camera.ts
@@ -6,6 +6,7 @@ import { getChatBallonXY } from '../graphics/graphicsUtils';
 
 const cameraPadding = 0.3;
 export const characterHeight = 25;
+export const characterWidth = 24;
 
 export function createCamera(): Camera {
 	return {
@@ -28,7 +29,12 @@ export function setupCamera(camera: Camera, x: number, y: number, width: number,
 	camera.y = clamp(y, 0, toScreenY(map.height) - camera.h);
 }
 
-export function updateCamera(camera: Camera, player: Point, map: Size) {
+export function updateCamera(
+	camera: Camera,
+	player: Point,
+	map: Size,
+	panning?: Point,
+) {
 	// camera.x and camera.y are the coordinate of the *top left corner*
 	// of the camera
 
@@ -36,13 +42,13 @@ export function updateCamera(camera: Camera, player: Point, map: Size) {
 	// The concept of a pixel in pixel.horse graphics
 	// -- same as a screen pixel when the zoom is 1
 
-	const cameraWith = camera.w;
+	const cameraWidth = camera.w;
 	const cameraHeight = camera.h;
 	const cameraHeightShifted = Math.ceil(camera.h - camera.offset);
 
 	// (A)
 	// player.x / y and map.width / height are counted in tiles rather
-	// than ptxels, so this is a conversion step from tilecount to pixel
+	// than ptxels, so this is a conversion step from tilecount to ptxel
 	// location
 	const playerX = toScreenX(player.x);
 	const playerY = toScreenY(player.y);
@@ -61,41 +67,68 @@ export function updateCamera(camera: Camera, player: Point, map: Size) {
 	// Technically, it centers the top left corner of the map inside all
 	// the empty space that could be found to the top and the left of
 	// the map, if the map was placed to the bottom right of the screen.
-	const minX = Math.min(0, (mapWidth - cameraWith) / 2);
+	const minX = Math.min(0, (mapWidth - cameraWidth) / 2);
 	const minY = Math.min(0, (mapHeight - cameraHeight) / 2);
 	const minYShifted = Math.min(0, (mapHeight - cameraHeightShifted) / 2);
-	const maxX = Math.max(mapWidth - cameraWith, minX);
+	const maxX = Math.max(mapWidth - cameraWidth, minX);
 	const maxY = Math.max(mapHeight - cameraHeight, minY);
 	const maxYShifted = Math.max(mapHeight - cameraHeightShifted, minY);
 
-	// (C)
-	// hSpace / vSpace are the room at the center of the camera where
-	// the creature can move without having the camera follow them.
-	const hSpace = Math.floor(cameraWith * cameraPadding);
-	const vSpace = Math.floor(cameraHeight * cameraPadding);
-	const vSpaceShifted = Math.floor(cameraHeightShifted * cameraPadding);
+	const padCamera = !panning;
 
-	// (D)
-	// hPad / vPad are the sizes of the bands to the sides of that
-	// central room
-	const hPad = (cameraWith - hSpace) / 2;
-	const vPad = (cameraHeight - vSpace) / 2;
-	const vPadShifted = (cameraHeightShifted - vSpaceShifted) / 2;
+	let minCamX: number;
+	let maxCamX: number;
+	let minCamY: number;
+	let maxCamY: number;
+	let minCamYShifted: number;
+	let maxCamYShifted: number;
 
-	// (E)
-	// The below block actually computes the locations of these bands,
-	// in terms of the X/Y coordinates of the camera. If the map is too
-	// small, minX/Y / maxX/Y kick in and just center the map.
-	const minCamX = clamp(playerX - (hSpace + hPad), minX, maxX);
-	const maxCamX = clamp(playerX - hPad, minX, maxX);
-	const minCamY = clamp(playerY - (vSpace + vPad) - characterHeight, minY, maxY);
-	const maxCamY = clamp(playerY - vPad - characterHeight, minY, maxY);
-	const minCamYShifted = clamp(playerY - (vSpaceShifted + vPadShifted) - characterHeight, minYShifted, maxYShifted);
-	const maxCamYShifted = clamp(playerY - vPadShifted - characterHeight, minYShifted, maxYShifted);
+	if (padCamera) {
+		// (C)
+		// hSpace / vSpace are the room at the center of the camera where
+		// the creature can move without having the camera follow them.
+		const hSpace = Math.floor(cameraWidth * cameraPadding);
+		const vSpace = Math.floor(cameraHeight * cameraPadding);
+		const vSpaceShifted = Math.floor(cameraHeightShifted * cameraPadding);
+
+		// (D)
+		// hPad / vPad are the sizes of the bands to the sides of that
+		// central room
+		const hPad = (cameraWidth - hSpace) / 2;
+		const vPad = (cameraHeight - vSpace) / 2;
+		const vPadShifted = (cameraHeightShifted - vSpaceShifted) / 2;
+
+		// (E1)
+		// The below block actually computes the locations of these
+		// bands, in terms of the X/Y coordinates of the camera.
+		// If the player is near an edge of the map, minX/Y / maxX/Y
+		// kick in to force pervent the camera from poking out of the
+		// map.
+		minCamX = clamp(playerX - (hSpace + hPad), minX, maxX);
+		maxCamX = clamp(playerX - hPad, minX, maxX);
+		minCamY = clamp(playerY - (vSpace + vPad) - characterHeight, minY, maxY);
+		maxCamY = clamp(playerY - vPad - characterHeight, minY, maxY);
+		minCamYShifted = clamp(playerY - (vSpaceShifted + vPadShifted) - characterHeight, minYShifted, maxYShifted);
+		maxCamYShifted = clamp(playerY - vPadShifted - characterHeight, minYShifted, maxYShifted);
+	} else {
+		// (E2)
+		// With no padding, we just want to make sure the player is visible.
+		// minX/Y and maxX/Y play the same role as in (E1)
+		minCamX = clamp(playerX + characterWidth - cameraWidth, minX, maxX);
+		maxCamX = clamp(playerX - characterWidth, minX, maxX);
+		minCamY = clamp(playerY + 2 * characterHeight - cameraHeight - characterHeight, minY, maxY);
+		maxCamY = clamp(playerY - 3 * characterHeight, minY, maxY);
+		minCamYShifted = clamp(playerY + 2 * characterHeight - cameraHeight, minYShifted, maxYShifted);
+		maxCamYShifted = clamp(playerY - 3 * characterHeight, minYShifted, maxYShifted);
+	}
 
 	// (F)
 	// Finally, we need to move the camera only when the creature is
 	// pressing against one of the earlier defined sides
+	if (panning) {
+		camera.x = playerX - cameraWidth / 2 + panning.x;
+		camera.y = playerY - cameraHeight / 2 + panning.y;
+	}
 	camera.x = Math.floor(clamp(camera.x, minCamX, maxCamX));
 	camera.y = Math.floor(clamp(camera.y, minCamY, maxCamY));
 	camera.shiftTarget = Math.floor(clamp(camera.shiftTarget, minCamYShifted, maxCamYShifted));
@@ -103,9 +136,9 @@ export function updateCamera(camera: Camera, player: Point, map: Size) {
 
 	// Note:
 	// The logic for computing the camera position does not need steps
-	// (B), (C) and (D) to be run each time. These must be recomputed
-	// only when the camera is changed. Only (A), (E) and (F) depend on
-	// the creature position
+	// (B), (C) and (D) to be run each time, as it is currently the case
+	// These must be recomputed only when the camera is changed.
+	// Only (A), (E) and (F) depend on the creature position.
 }
 
 export function centerCameraOn(camera: Camera, point: Point) {
@@ -165,6 +198,13 @@ export function worldToScreen(camera: Camera, point: Point): Point {
 	return {
 		x: Math.floor(toScreenX(point.x) - camera.x),
 		y: Math.floor(toScreenY(point.y) - camera.actualY),
+	};
+}
+
+export function screenToPanning(camera: Camera, cursor: Point): Point {
+	return {
+		x: (cursor.x / camera.w - 0.5) * camera.w,
+		y: (cursor.y / camera.h - 0.5) * (camera.h + 2 * characterHeight),
 	};
 }
 

--- a/src/ts/components/app/help/help.pug
+++ b/src/ts/components/app/help/help.pug
@@ -70,6 +70,9 @@ h1(focusTitle) Help
 					#[kbd-key(title="P key") P] and #[kbd-key(title="O key") O]
 					or #[kbd-key.gamepad.gamepad-yellow(title="Gamepad Y button") Y]
 				li.
+					#[b panning] -
+					hold down both #[kbd-key(title="control key") ctrl] and left click to pann around
+				li.
 					#[b hide all text] -
 					#[kbd-key(title="F2 key") F2]
 				li.

--- a/src/ts/tests/common/camera.spec.ts
+++ b/src/ts/tests/common/camera.spec.ts
@@ -2,7 +2,7 @@ import '../lib';
 import { expect } from 'chai';
 import {
 	updateCamera, centerCameraOn, isWorldPointVisible, isEntityVisible, isAreaVisible,
-	isRectVisible, screenToWorld, worldToScreen, createCamera
+	isRectVisible, screenToWorld, worldToScreen, createCamera, screenToPanning
 } from '../../common/camera';
 import { rect } from '../../common/rect';
 import { entity } from '../mocks';
@@ -80,6 +80,29 @@ describe('Camera', () => {
 
 			expect(camera.x).equal(toScreenX(-25), 'x');
 			expect(camera.y).equal(toScreenY(-25), 'y');
+		});
+
+		it('takes the panning argument into account, when passed', () => {
+			const camera = {
+				...createCamera(),
+				w: toScreenX(100),
+				h: toScreenX(100),
+			};
+
+			const player = { x: 50, y: 50 };
+
+			updateCamera(camera, player, { width: 1000, height: 1000 }, { x: 0, y: 0});
+
+			expect(camera.x).equal(player.x, 'x');
+			expect(camera.y).equal(player.y, 'y');
+
+			const x = 40;
+			const y = 20;
+
+			updateCamera(camera, player, { width: 1000, height: 1000 }, { x, y });
+
+			expect(camera.x).equal(player.x + x, 'x');
+			expect(camera.y).equal(player.y + y, 'y');
 		});
 	});
 
@@ -167,6 +190,34 @@ describe('Camera', () => {
 			camera.actualY = camera.y = 24;
 
 			expect(worldToScreen(camera, { x: 3, y: 3 })).eql({ x: 64, y: 48 });
+		});
+	});
+
+	describe('screenToPanning()', () => {
+		it('maps the center of the screen to the zero padding', () => {
+			const w = 200;
+			const h = 100;
+
+			const camera = {
+				...createCamera(),
+				w,
+				h
+			};
+
+			expect(screenToPanning(camera, { x: w / 2, y: h / 2 })).eql({ x: 0, y: 0 });
+		});
+
+		it('maps the top left of the screen to panning half a screen up left', () => {
+			const w = 200;
+			const h = 100;
+
+			const camera = {
+				...createCamera(),
+				w,
+				h
+			};
+
+			expect(screenToPanning(camera, { x: 0, y: 0 })).eql({ x: -camera.w / 2, y: -camera.h / 2 });
 		});
 	});
 });


### PR DESCRIPTION
#60

## Changes

- Document exisiting function `updateCamera` (of `camera.ts`) to explain its different parts
- Add an optional argument `panning` to `updateCamera` which changes the way the camera position is computed
- Add a method `screenToPanning` computing the panning amount from the mouse position
- Add a property `private panning?: Point` to `Game` (`game.ts`), pass it to `updateCamera` in the two calls in `update` (of `Game`), after computing `panning` at each tick using `screenToPanning`, only if the mouse left button is down and ctrl is pressed

## Note

No support for mobiles (yet).
No panning relative to where the click began (yet).