### PR TITLE
Hotfix: Don't include email from Discord if we don't receive it

### DIFF
--- a/src/ts/server/oauth.ts
+++ b/src/ts/server/oauth.ts
@@ -121,6 +121,8 @@ export function getProfileUrl(profile: OAuthProfile): string | undefined {
 
 export function getProfileEmails(profile: OAuthProfile): string[] {
 	if (profile.provider === 'discord') {
+		// TODO: diagnose why we aren't receiving the email from Discord
+		// for now, we just won't attempt to record an email if we don't receive one
 		return profile.email ? [profile.email] : [];
 	} else if (profile.emails && profile.emails.length) {
 		return profile.emails.map(e => e.value);

--- a/src/ts/server/oauth.ts
+++ b/src/ts/server/oauth.ts
@@ -121,7 +121,7 @@ export function getProfileUrl(profile: OAuthProfile): string | undefined {
 
 export function getProfileEmails(profile: OAuthProfile): string[] {
 	if (profile.provider === 'discord') {
-		return [profile.email as string];
+		return profile.email ? [profile.email] : [];
 	} else if (profile.emails && profile.emails.length) {
 		return profile.emails.map(e => e.value);
 	} else if (profile._json && profile._json.attributes && profile._json.attributes.email) { // patreon


### PR DESCRIPTION
TODO: diagnose *why* we aren't receiving the email from Discord