### PR TITLE
Actions: add pull_request event

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,5 @@
 name: Push Checks
-on: push
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
Should fix forks not having checks ran. With this approach, future changes to .github/workflows will need to be done in this repo (not within a fork) unless you view the workflow check status in the fork since GH will always run the host repo's workflows when performing the PR checks on a fork.