### PR TITLE
Actions: use Node 10.x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '10.x'
       - name: install gulp
         run: bash .github/ci-install-gulp.sh
       - run: npm ci
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '10.x'
       - name: install gulp
         run: bash .github/ci-install-gulp.sh
       - run: npm ci


### PR DESCRIPTION
Since Pony Town requires Node 9 (and Node 10 seems to work), may as well do this now while we wait for tests to be fixed