### PR TITLE
Add excite action

### DIFF
--- a/src/ts/client/buttonActions.ts
+++ b/src/ts/client/buttonActions.ts
@@ -11,7 +11,7 @@ import { PonyTownGame } from './game';
 import { boopAction, upAction, downAction, turnHeadAction } from './playerActions';
 import { ACTIONS_LIMIT, COMMAND_ACTION_TIME_DELAY } from '../common/constants';
 import { cloneDeep, hasFlag } from '../common/utils';
-import { boop, defaultHeadFrame, stand, sneeze, yawn, lie, sit, fly, laugh } from './ponyAnimations';
+import { boop, defaultHeadFrame, stand, sneeze, yawn, lie, sit, fly, laugh, excite } from './ponyAnimations';
 import { createDefaultPony, syncLockedPonyInfo, toPalette, mockPaletteManager } from '../common/ponyInfo';
 import {
 	ACTION_EXPRESSION_EYE_COLOR, ACTION_EXPRESSION_BG, ACTION_ACTION_COAT_COLOR, WHITE, HEARTS_COLOR,
@@ -113,6 +113,7 @@ const actionActions = [
 	actionButtonAction('yawn', 'Yawn', Action.Yawn),
 	actionButtonAction('love', 'Love', Action.Love),
 	actionButtonAction('laugh', 'Laugh', Action.Laugh),
+	actionButtonAction('excite', 'Excite', Action.Excite),
 	actionButtonAction('blush', 'Blush', Action.Blush),
 	actionButtonAction('drop', 'Drop item', Action.Drop),
 	actionButtonAction('drop-toy', 'Drop toy', Action.DropToy),
@@ -469,6 +470,11 @@ export function drawAction(canvas: HTMLCanvasElement, action: ButtonAction | und
 							}
 							case 'sneeze': {
 								const state = { ...createState(), headAnimation: sneeze, headAnimationFrame: 3 };
+								drawPony(batch, actionPony, state, 17, 40, defaultDrawPonyOptions());
+								break;
+							}
+							case 'excite': {
+								const state = { ...createState(), headAnimation: excite, headAnimationFrame: 3 };
 								drawPony(batch, actionPony, state, 17, 40, defaultDrawPonyOptions());
 								break;
 							}

--- a/src/ts/client/handlers.ts
+++ b/src/ts/client/handlers.ts
@@ -25,7 +25,7 @@ import { decodeUpdate, readOneUpdate } from '../common/encoders/updateDecoder';
 import { updateEntityVelocity } from '../common/entityUtils';
 import { decodePonyInfo } from '../common/compressPony';
 import { mockPaletteManager } from '../common/ponyInfo';
-import { yawn, laugh, sneeze } from './ponyAnimations';
+import { yawn, laugh, sneeze, excite } from './ponyAnimations';
 import {
 	findEntityById, getRegionGlobal, setTile, removeEntity, addEntity, removeEntityDirectly, setRegion,
 	addEntityToMapRegion, switchEntityRegion, getRegionUnsafe, addOrRemoveFromEntityList,
@@ -413,6 +413,11 @@ export function handleAction(game: PonyTownGame, id: number, action: Action) {
 			case Action.Sneeze:
 				if (!hasHeadAnimation(pony)) {
 					setHeadAnimation(pony, sneeze);
+				}
+				break;
+			case Action.Excite:
+				if (!hasHeadAnimation(pony)) {
+					setHeadAnimation(pony, excite);
 				}
 				break;
 			default:

--- a/src/ts/common/interfaces.ts
+++ b/src/ts/common/interfaces.ts
@@ -1093,6 +1093,7 @@ export const enum Action {
 	SwitchToolRev,
 	SwitchToPlaceTool,
 	SwitchToTileTool,
+	Excite,
 }
 
 export const enum InfoFlags {
@@ -1103,7 +1104,7 @@ export const enum InfoFlags {
 }
 
 export function isExpressionAction(action: Action) {
-	return action === Action.Yawn || action === Action.Laugh || action === Action.Sneeze;
+	return action === Action.Yawn || action === Action.Laugh || action === Action.Sneeze || action === Action.Excite;
 }
 
 export interface EditorPlaceAction {

--- a/src/ts/components/app/help/help.pug
+++ b/src/ts/components/app/help/help.pug
@@ -141,6 +141,7 @@ h1(focusTitle) Help
 					<code>/yawn</code>
 					<code>/laugh</code> <code>/haha</code> <code>/хаха</code> <code>/jaja</code> <code>/lol</code>
 					<code>/sneeze</code> <code>/achoo</code>
+					<code>/excite</code> <code>/tada</code>
 				li
 					strong House saving
 					ul

--- a/src/ts/components/shared/chat-box/chat-box.ts
+++ b/src/ts/components/shared/chat-box/chat-box.ts
@@ -34,7 +34,7 @@ setupChatType(ChatType.Think, 'think');
 setupChatType(ChatType.PartyThink, 'party think');
 
 function isActionCommand(message: string) {
-	return /^\/(yawn|sneeze|achoo|laugh|lol|haha|хаха|jaja)/i.test(message);
+	return /^\/(yawn|sneeze|excite|tada|achoo|laugh|lol|haha|хаха|jaja)/i.test(message);
 }
 
 @Component({

--- a/src/ts/server/commands.ts
+++ b/src/ts/server/commands.ts
@@ -275,6 +275,7 @@ export function createCommands(world: World): Command[] {
 		action(['yawn'], Action.Yawn),
 		action(['laugh', 'lol', 'haha', 'хаха', 'jaja'], Action.Laugh),
 		action(['sneeze', 'achoo'], Action.Sneeze),
+		action(['excite', 'tada'], Action.Excite),
 		action(['magic'], Action.Magic),
 
 		// house


### PR DESCRIPTION
Adds the `/tada` and `/excite` command, both referring to the same head animation.
Additionally, a fitting action button is added too.

Suggestions for a better name are welcome. :horse: 